### PR TITLE
bump to v2025-06-15

### DIFF
--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -3,7 +3,7 @@ speakeasyVersion: latest
 sources:
     GustoEmbedded-OAS:
         inputs:
-            - location: https://raw.githubusercontent.com/Gusto/Gusto-Partner-API/refs/heads/main/generated/embedded/api.v2024-04-01.embedded.yaml
+            - location: https://raw.githubusercontent.com/Gusto/Gusto-Partner-API/refs/heads/main/generated/embedded/api.v2025-06-15.embedded.yaml
               authHeader: Authorization
               authSecret: $openapi_doc_auth_token
         overlays:


### PR DESCRIPTION
References the new generated openapi spec file for [v2025-06-15](https://github.com/Gusto/Gusto-Partner-API/pull/1249)