### PR TITLE
feat: add MIT license to Speakeasy SDK generation

### DIFF
--- a/.speakeasy/workflow.local.yaml
+++ b/.speakeasy/workflow.local.yaml
@@ -1,0 +1,13 @@
+workflowVersion: 1.0.0
+speakeasyVersion: latest
+sources:
+  GustoEmbedded-local:
+    inputs:
+      - location: ../Gusto-Partner-API/generated/embedded/api.v2025-06-15.embedded.yaml
+    overlays:
+      - location: ../Gusto-Partner-API/.speakeasy/speakeasy-modifications-overlay.yaml
+targets:
+  local:
+    target: java
+    source: GustoEmbedded-local
+    output: ./gusto_embedded

--- a/gusto_embedded/.speakeasy/gen.yaml
+++ b/gusto_embedded/.speakeasy/gen.yaml
@@ -40,9 +40,9 @@ java:
   asyncMode: enabled
   baseErrorName: GustoEmbeddedException
   clientServerStatusCodesAsErrors: true
-  companyEmail: info@mycompany.com
-  companyName: My Company
-  companyURL: www.mycompany.com
+  companyEmail: developer@gusto.com
+  companyName: Gusto
+  companyURL: gusto.com
   defaultErrorName: APIException
   enableCustomCodeRegions: false
   enableFormatting: false
@@ -55,7 +55,7 @@ java:
   generateOptionalUnionAccessors: false
   generateSpringBootStarter: true
   generateUnionDocs: false
-  githubURL: github.com/owner/repo
+  githubURL: github.com/Gusto/gusto-java-client
   groupID: com.gusto
   imports:
     option: openapi

--- a/gusto_embedded/.speakeasy/gen.yaml
+++ b/gusto_embedded/.speakeasy/gen.yaml
@@ -24,10 +24,6 @@ generation:
   requestBodyFieldName: ""
   versioningStrategy: automatic
   persistentEdits: {}
-  license:
-    disabled: false
-    licenseType: MIT
-    companyName: Gusto
   tests:
     generateTests: true
     generateNewTests: false

--- a/gusto_embedded/.speakeasy/gen.yaml
+++ b/gusto_embedded/.speakeasy/gen.yaml
@@ -24,6 +24,10 @@ generation:
   requestBodyFieldName: ""
   versioningStrategy: automatic
   persistentEdits: {}
+  license:
+    disabled: false
+    licenseType: MIT
+    companyName: Gusto
   tests:
     generateTests: true
     generateNewTests: false

--- a/gusto_embedded/LICENSE
+++ b/gusto_embedded/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Gusto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary

- Fixes placeholder metadata in \`gen.yaml\`: \`companyName\`, \`companyEmail\`, \`companyURL\`, and \`githubURL\`
- Manually adds \`gusto_embedded/LICENSE\` (MIT)
- Adds \`.speakeasy/workflow.local.yaml\` for running \`speakeasy run --target=local\` during local development

> **Note:** The \`java.license\` block with full MIT details (\`name\`, \`shortName\`, \`url\`) was already correctly present in \`gen.yaml\` prior to this PR, which sets the license metadata in \`publishing.gradle\`.

## Test plan

- [x] Run \`speakeasy run --target=local\` locally and confirm generation succeeds
- [x] Confirm \`publishing.gradle\` reflects \`The MIT License (MIT)\` and correct Gusto company metadata
- [x] Confirm \`gusto_embedded/LICENSE\` exists with MIT license text