### PR TITLE
chore: bump API version to 2026-06-15

### DIFF
--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -1,46 +1,68 @@
+---
 workflowVersion: 1.0.0
 speakeasyVersion: latest
 sources:
-    GustoEmbedded-OAS:
-        inputs:
-            - location: https://raw.githubusercontent.com/Gusto/Gusto-Partner-API/refs/heads/main/generated/embedded/api.v2025-06-15.embedded.yaml
-              authHeader: Authorization
-              authSecret: $openapi_doc_auth_token
-        overlays:
-            - location: https://raw.githubusercontent.com/Gusto/Gusto-Partner-API/refs/heads/main/.speakeasy/speakeasy-modifications-overlay.yaml
-              authHeader: Authorization
-              authSecret: $openapi_doc_auth_token
-        registry:
-            location: registry.speakeasyapi.dev/gusto/ruby-sdk/gusto-embedded-oas
-    GustoEmbedded-OAS-v2025-11-15:
-        inputs:
-            - location: https://raw.githubusercontent.com/Gusto/Gusto-Partner-API/refs/heads/main/generated/embedded/api.v2025-11-15.embedded.yaml
-              authHeader: Authorization
-              authSecret: $openapi_doc_auth_token
-        overlays:
-            - location: https://raw.githubusercontent.com/Gusto/Gusto-Partner-API/refs/heads/main/.speakeasy/speakeasy-modifications-overlay.yaml
-              authHeader: Authorization
-              authSecret: $openapi_doc_auth_token
-        registry:
-            location: registry.speakeasyapi.dev/gusto/ruby-sdk/gusto-embedded-oas-v2025-11-15
+  GustoEmbedded-OAS:
+    inputs:
+    - location: https://raw.githubusercontent.com/Gusto/Gusto-Partner-API/refs/heads/main/generated/embedded/api.v2025-06-15.embedded.yaml
+      authHeader: Authorization
+      authSecret: "$openapi_doc_auth_token"
+    overlays:
+    - location: https://raw.githubusercontent.com/Gusto/Gusto-Partner-API/refs/heads/main/.speakeasy/speakeasy-modifications-overlay.yaml
+      authHeader: Authorization
+      authSecret: "$openapi_doc_auth_token"
+    registry:
+      location: registry.speakeasyapi.dev/gusto/ruby-sdk/gusto-embedded-oas
+  GustoEmbedded-OAS-v2025-11-15:
+    inputs:
+    - location: https://raw.githubusercontent.com/Gusto/Gusto-Partner-API/refs/heads/main/generated/embedded/api.v2025-11-15.embedded.yaml
+      authHeader: Authorization
+      authSecret: "$openapi_doc_auth_token"
+    overlays:
+    - location: https://raw.githubusercontent.com/Gusto/Gusto-Partner-API/refs/heads/main/.speakeasy/speakeasy-modifications-overlay.yaml
+      authHeader: Authorization
+      authSecret: "$openapi_doc_auth_token"
+    registry:
+      location: registry.speakeasyapi.dev/gusto/ruby-sdk/gusto-embedded-oas-v2025-11-15
+  GustoEmbedded-OAS-v2026-06-15:
+    inputs:
+    - location: https://raw.githubusercontent.com/Gusto/Gusto-Partner-API/refs/heads/main/generated/embedded/api.v2026-06-15.embedded.yaml
+      authHeader: Authorization
+      authSecret: "$openapi_doc_auth_token"
+    overlays:
+    - location: https://raw.githubusercontent.com/Gusto/Gusto-Partner-API/refs/heads/main/.speakeasy/speakeasy-modifications-overlay.yaml
+      authHeader: Authorization
+      authSecret: "$openapi_doc_auth_token"
+    registry:
+      location: registry.speakeasyapi.dev/gusto/ruby-sdk/gusto-embedded-oas-v2026-06-15
 targets:
-    gusto-embedded:
-        target: java
-        source: GustoEmbedded-OAS
-        output: ./gusto_embedded
-        codeSamples:
-            registry:
-                location: registry.speakeasyapi.dev/gusto/ruby-sdk/gusto-embedded-oas-java-code-samples
-            labelOverride:
-                fixedValue: Java (SDK)
-            blocking: false
-    gusto-embedded-v2025-11-15:
-        target: java
-        source: GustoEmbedded-OAS-v2025-11-15
-        output: ./gusto_embedded_v_2025_11_15
-        codeSamples:
-            registry:
-                location: registry.speakeasyapi.dev/gusto/ruby-sdk/gusto-embedded-oas-java-code-samples-v2025-11-15-code-samples
-            labelOverride:
-                fixedValue: Java (SDK)
-            blocking: false
+  gusto-embedded:
+    target: java
+    source: GustoEmbedded-OAS
+    output: "./gusto_embedded"
+    codeSamples:
+      registry:
+        location: registry.speakeasyapi.dev/gusto/ruby-sdk/gusto-embedded-oas-java-code-samples
+      labelOverride:
+        fixedValue: Java (SDK)
+      blocking: false
+  gusto-embedded-v2025-11-15:
+    target: java
+    source: GustoEmbedded-OAS-v2025-11-15
+    output: "./gusto_embedded_v_2025_11_15"
+    codeSamples:
+      registry:
+        location: registry.speakeasyapi.dev/gusto/ruby-sdk/gusto-embedded-oas-java-code-samples-v2025-11-15-code-samples
+      labelOverride:
+        fixedValue: Java (SDK)
+      blocking: false
+  gusto-embedded-v2026-06-15:
+    target: java
+    source: GustoEmbedded-OAS-v2026-06-15
+    output: "./gusto_embedded_v_2026_06_15"
+    codeSamples:
+      registry:
+        location: registry.speakeasyapi.dev/gusto/ruby-sdk/gusto-embedded-oas-java-code-samples-v2026-06-15
+      labelOverride:
+        fixedValue: Java (SDK)
+      blocking: false

--- a/gusto_embedded_v_2026_06_15/.speakeasy/gen.yaml
+++ b/gusto_embedded_v_2026_06_15/.speakeasy/gen.yaml
@@ -1,0 +1,83 @@
+---
+configVersion: 2.0.0
+generation:
+  sdkClassName: GustoEmbedded
+  maintainOpenAPIOrder: true
+  usageSnippets:
+    optionalPropertyRendering: withExample
+    sdkInitStyle: constructor
+  useClassNamesForArrayFields: true
+  fixes:
+    nameResolutionDec2023: true
+    nameResolutionFeb2025: false
+    parameterOrderingFeb2024: true
+    requestResponseComponentNamesFeb2024: true
+    securityFeb2025: true
+    sharedErrorComponentsApr2025: false
+    sharedNestedComponentsJan2026: false
+    nameOverrideFeb2026: false
+  auth:
+    oAuth2ClientCredentialsEnabled: true
+    oAuth2PasswordEnabled: true
+    hoistGlobalSecurity: true
+  schemas:
+    allOfMergeStrategy: shallowMerge
+  requestBodyFieldName: ''
+  versioningStrategy: automatic
+  persistentEdits: {}
+  tests:
+    generateTests: true
+    generateNewTests: false
+    skipResponseBodyAssertions: false
+java:
+  version: 0.0.1
+  additionalDependencies: []
+  additionalPlugins: []
+  artifactID: embedded-api-v-2026-06-15
+  asyncMode: enabled
+  baseErrorName: GustoEmbeddedException
+  clientServerStatusCodesAsErrors: true
+  companyEmail: developer@gusto.com
+  companyName: Gusto
+  companyURL: gusto.com
+  defaultErrorName: APIException
+  enableCustomCodeRegions: false
+  enableFormatting: false
+  enableSlf4jLogging: false
+  enableStreamingUploads: false
+  explicitDocImports: false
+  flattenGlobalSecurity: true
+  forwardCompatibleEnumsByDefault: false
+  forwardCompatibleUnionsByDefault: 'false'
+  generateOptionalUnionAccessors: false
+  generateSpringBootStarter: true
+  generateUnionDocs: false
+  githubURL: github.com/Gusto/gusto-java-client
+  groupID: com.gusto
+  imports:
+    option: openapi
+    paths:
+      callbacks: models/callbacks
+      errors: models/errors
+      operations: models/operations
+      shared: models/components
+      webhooks: models/webhooks
+  inferUnionDiscriminators: false
+  inputModelSuffix: input
+  languageVersion: 11
+  license:
+    name: The MIT License (MIT)
+    shortName: MIT
+    url: https://mit-license.org/
+  maxMethodParams: 4
+  multipartArrayFormat: legacy
+  nullFriendlyParameters: false
+  operationScopedParams: true
+  outputModelSuffix: output
+  prefixModeMethodNames: false
+  projectName: GustoEmbedded
+  respectTitlesForPrimitiveUnionMembers: false
+  showSetterGetterTypesInDocs: false
+  templateVersion: v2
+  unionStrategy: populated-fields
+  packageName: com.gusto.embedded_api_v_2026_06_15


### PR DESCRIPTION
## Summary
- Adds versioned SDK directory and workflow entries for API version `2026-06-15`
- Existing entries are frozen at their current version for backwards compatibility

## Notes
Merge the Gusto-Partner-API PR first before merging this PR.